### PR TITLE
Bump spring-boot-starter-parent from 1.5.6.RELEASE to 2.0.6.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.6.RELEASE</version>
+        <version>2.0.6.RELEASE</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Bumps spring-boot-starter-parent from 1.5.6.RELEASE to 2.0.6.RELEASE.

@hahaha